### PR TITLE
fix: add missing ion-icon closing tag

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -276,7 +276,11 @@
                 <!-- END: Your slides -->
 
                 <div slot="footer">
-                    <deckgo-social twitter="deckdeckgo"><ion-icon name="logo-twitter" aria-label="Twitter" style="color: #00aced; font-size: 1.4em;" slot="icon">@deckdeckgo</deckgo-social>
+                    <deckgo-social twitter="deckdeckgo">
+                        <ion-icon name="logo-twitter" aria-label="Twitter" style="color: #00aced; font-size: 1.4em;" slot="icon">
+                            @deckdeckgo
+                        <ion-icon/>
+                    </deckgo-social>
                 </div>
 
             </deckgo-deck>


### PR DESCRIPTION
The footer is missing the closing `</icon-icon>` tag. This is preventing tools like Prettier from formatting the code properly.